### PR TITLE
Fix MSVC signed enum bitfield in JSClosureVar

### DIFF
--- a/quickjs/quickjs.c
+++ b/quickjs/quickjs.c
@@ -566,7 +566,7 @@ typedef enum {
 } JSClosureTypeEnum;
 
 typedef struct JSClosureVar {
-    JSClosureTypeEnum closure_type : 3;
+    uint8_t closure_type : 3;  /* JSClosureTypeEnum - explicitly use uint8_t to avoid implementation-defined behavior */
     uint8_t is_lexical : 1; /* lexical variable */
     uint8_t is_const : 1; /* const variable (is_lexical = 1 if is_const = 1 */
     uint8_t var_kind : 4; /* see JSVarKindEnum */


### PR DESCRIPTION
Fix crash issue (as soon as campaign or tutorial loads) when building 3rdparty/quickjs-wz/ and Warzone with MSVC. 

The official Warzone releases are not built with MSVC and consider enum bitfields as unsigned. But when built with MSVC (Visual Studio), closure_type's 3-bit enum bitfield is interpreted as signed, causing values 4-7 to be read as -4 to -1. 

The enum has values 0-7 (for example JS_CLOSURE_GLOBAL_DECL = 4). A 3-bit field can store 0-7.

MSVC treats enum bitfields as signed by default. A signed 3-bit field has range -4 to +3. So when the code uses value 4, MSVC read it back as -4 (same bit pattern 100, different interpretation).

The fix changes the type to uint8_t which is explicitly unsigned.

The only minor downside is losing the enum type annotation  - you lose compile-time checking that only valid JSClosureTypeEnum values are assigned. 